### PR TITLE
73: Wrap long words on titles and messages

### DIFF
--- a/src/components/Channels/ChannelListItem.vue
+++ b/src/components/Channels/ChannelListItem.vue
@@ -1,6 +1,9 @@
 <template>
   <router-link :to="channelLink" :class="getChannelClass(item)">
-    <div class="col-span-5 text-lg">
+    <div
+      class="col-span-5 text-lg overflow-hidden"
+      style="text-overflow: ellipsis"
+    >
       {{ item.name }}
       <LockClosedIcon v-if="isPrivate(item)" class="h-5 w-5 inline-block" />
     </div>

--- a/src/components/Messages/MessageViewItem.vue
+++ b/src/components/Messages/MessageViewItem.vue
@@ -1,6 +1,8 @@
 <template>
-  <div class="flex justify-between items-center px-1 text-sm hover:bg-gray-100">
-    <div>
+  <div
+    class="flex justify-between items-center px-1 text-sm w-full overflow-hidden hover:bg-gray-100"
+  >
+    <div style="max-width: 92%">
       <p
         class="thread-message"
         :class="getMessageClass(item)"
@@ -130,6 +132,10 @@ const formattedBody = computed(() => {
 </style>
 
 <style>
+.thread-message {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
 .thread-message b {
   @apply cursor-pointer;
 }

--- a/src/components/Messages/MessageViewItem.vue
+++ b/src/components/Messages/MessageViewItem.vue
@@ -133,8 +133,8 @@ const formattedBody = computed(() => {
 
 <style>
 .thread-message {
+  @apply overflow-hidden;
   text-overflow: ellipsis;
-  overflow: hidden;
 }
 .thread-message b {
   @apply cursor-pointer;

--- a/src/components/Threads/ThreadListItem.vue
+++ b/src/components/Threads/ThreadListItem.vue
@@ -1,6 +1,11 @@
 <template>
   <router-link :to="threadLink" :class="getThreadClass(item)">
-    <div class="col-span-8 text-base">{{ item.name }}</div>
+    <div
+      class="col-span-8 text-base overflow-hidden"
+      style="text-overflow: ellipsis"
+    >
+      {{ item.name }}
+    </div>
     <div class="col-span-1 font-semibold justify-self-end">
       <BookmarkIcon
         :class="item.isFollowed ? 'fill-current text-red-500' : ''"

--- a/src/views/MessagesPage.vue
+++ b/src/views/MessagesPage.vue
@@ -306,7 +306,7 @@ textarea {
   resize: none;
 }
 .messages-title {
+  @apply overflow-hidden;
   text-overflow: ellipsis;
-  overflow: hidden;
 }
 </style>

--- a/src/views/MessagesPage.vue
+++ b/src/views/MessagesPage.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="flex justify-between items-center gap-2">
-    <h2 class="text-red-500 text-2xl my-2 font-bold">{{ thread.name }}</h2>
+    <h2 class="text-red-500 text-2xl my-2 font-bold messages-title">
+      {{ thread.name }}
+    </h2>
     <div :title="showChatOnly ? 'Show threads list' : 'Show chat only'">
       <component
         :is="showChatOnly ? ViewBoardsIcon : EyeIcon"
@@ -302,5 +304,9 @@ onUnmounted(() => {
 <style scoped>
 textarea {
   resize: none;
+}
+.messages-title {
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 </style>

--- a/src/views/ThreadsPage.vue
+++ b/src/views/ThreadsPage.vue
@@ -2,7 +2,7 @@
   <div class="mx-auto w-11/12 lg:w-3/5">
     <div v-show="!showChatOnly" class="w-1/2 float-left">
       <div class="mr-2">
-        <h2 class="text-red-500 text-2xl my-2 font-bold">
+        <h2 class="text-red-500 text-2xl my-2 font-bold threads-title">
           {{ channel.name }}
         </h2>
         <ThreadList :items="sortedThreads" />
@@ -116,3 +116,9 @@ onUnmounted(() => {
   SocketioService.disconnect();
 });
 </script>
+<style scoped>
+.threads-title {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+</style>

--- a/src/views/ThreadsPage.vue
+++ b/src/views/ThreadsPage.vue
@@ -118,7 +118,7 @@ onUnmounted(() => {
 </script>
 <style scoped>
 .threads-title {
+  @apply overflow-hidden;
   text-overflow: ellipsis;
-  overflow: hidden;
 }
 </style>


### PR DESCRIPTION
- Updated the style rules for the thread and messages headings in order to automatically add ellipsis to the text when the content overflows the container
- Updated the channel and thread list item components to keep the content within the container as well
- Applied the same logic to the messages component