### PR TITLE
Prevent errors in socket service for logged-out users, addresses #45.

### DIFF
--- a/src/service/socket.service.js
+++ b/src/service/socket.service.js
@@ -53,7 +53,7 @@ class SocketioService {
         const { resolve } = this._requestCache[data.request];
         resolve(finalOnMessageHandler(data));
         delete this._requestCache[data.request];
-      } else if (data?.owner && user?.id && data.owner === user.id) {
+      } else if (data?.owner && user?.id && data.owner === user.id && data.request in this._requestCache) {
         const matchingKey = Object.keys(this._requestCache).find(
           (key) => this._requestCache[key].payload.message.body === data.body
         );


### PR DESCRIPTION
Messages from logged in users throw a JS error in the client for logged-out users because of conditional logic in the socket service which does not guard against this scenario and tries to look up a non-existent resolver. Checking if the resolver exists before using it fixes the bug.