### PR TITLE
switch to websockets first

### DIFF
--- a/src/service/socket.service.js
+++ b/src/service/socket.service.js
@@ -29,6 +29,7 @@ class SocketioService {
           `${socketServerUrl.protocol}//${socketServerUrl.host}`,
           {
             path: path,
+            transports: ["websocket"]
           }
         );
       };


### PR DESCRIPTION
This eliminates connection errors from the server by starting with websockets, instead of starting with long polling and upgrading to sockets.